### PR TITLE
fetch ticket data

### DIFF
--- a/components/TicketReference.vue
+++ b/components/TicketReference.vue
@@ -57,7 +57,7 @@
 <script>
 export default {
   props: ['blok'],
-  async mounted() {
+  async beforeCreate() {
     if(this.$store.state.references.ticketsLoaded !== '1') {
       try {
         const ticketData = await fetch(`${window.location.origin}/ticket-data.json`)

--- a/components/TicketReference.vue
+++ b/components/TicketReference.vue
@@ -57,6 +57,15 @@
 <script>
 export default {
   props: ['blok'],
+  async mounted() {
+    if(this.$store.state.references.ticketsLoaded !== '1') {
+      try {
+        const ticketData = await fetch(`${window.location.origin}/ticket-data.json`)
+        this.$store.commit('references/setTickets', ticketData)
+        this.$store.commit('references/setTicketsLoaded', '1')
+      } catch(e) {}
+    }
+  },
   computed: {
     tickets() {
       return this.$store.state.references.tickets

--- a/components/TicketReference.vue
+++ b/components/TicketReference.vue
@@ -60,7 +60,7 @@ export default {
   async beforeCreate() {
     if(this.$store.state.references.ticketsLoaded !== '1') {
       try {
-        const ticketData = await fetch(`${window.location.origin}/ticket-data.json`)
+        const ticketData = await fetch(`${window.location.origin}/ticket-data.json`).then(res => res.json())
         this.$store.commit('references/setTickets', ticketData)
         this.$store.commit('references/setTicketsLoaded', '1')
       } catch(e) {}

--- a/download.js
+++ b/download.js
@@ -1,0 +1,40 @@
+const axios = require('axios')
+
+function calculateLeft(release) {
+  const left = release.quantity - release.tickets_count
+  if(left > 15) {
+    return -1
+  }
+  return left
+}
+
+function download() {
+  return axios.get('https://api.tito.io/v3/scriptconf/tsconf-eu-2020/', {
+    headers: {
+      'Authorization': `Token token=${process.env.TITO_TOKEN}`,
+      'Content-Type': 'application/json'
+    }
+  })
+}
+
+function parseTickets(data) {
+  return data.data.event
+    .releases.filter(release => !release.secret)
+    .sort((a,b) => a.position - b.position)
+    .map(release => {
+      return {
+        title: release.title,
+        description: release.description,
+        slug: release.slug,
+        price: release.price,
+        url: release.share_url,
+        sold_out: release.sold_out,
+        left: calculateLeft(release)
+      }
+    })
+}
+
+module.exports = {
+  download,
+  parseTickets,
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,4 @@
-const axios = require('axios')
+const { download, parseTickets } = require('./download')
 
 export default {
   mode: 'universal',
@@ -85,35 +85,10 @@ export default {
       const version = 'published'
       let cache_version = 0
 
-      function calculateLeft(release) {
-        const left = release.quantity - release.tickets_count
-        if(left > 15) {
-          return -1
-        }
-        return left
-      }
-
-      axios.get('https://api.tito.io/v3/scriptconf/tsconf-eu-2020/', {
-        headers: {
-          'Authorization': `Token token=${process.env.TITO_TOKEN}`,
-          'Content-Type': 'application/json'
-        }
-      }).then(data => {
+      download().then(data => {
         try {
-          const titoTickets = data.data.event
-            .releases.filter(release => !release.secret)
-            .sort((a,b) => a.position - b.position)
-            .map(release => {
-              return {
-                title: release.title,
-                description: release.description,
-                slug: release.slug,
-                price: release.price,
-                url: release.share_url,
-                sold_out: release.sold_out,
-                left: calculateLeft(release)
-              }
-            })
+
+          const titoTickets = parseTickets(data)
           
           // other routes that are not in Storyblok with their slug.
           let routes = [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
-    "build": "nuxt generate",
+    "build": "nuxt generate && node post-generate.js",
     "start": "nuxt start",
     "old-build": "nuxt build",
     "generate": "nuxt generate"

--- a/pages/_.vue
+++ b/pages/_.vue
@@ -28,6 +28,8 @@ import Menu from '@/components/Menu.vue'
 import MobileMenu from '@/components/MobileMenu.vue'
 import Navigation from '@/components/Navigation.vue'
 
+import axios from 'axios'
+
 export default {
   computed: {
     isMainNavigationVisible() {
@@ -81,16 +83,14 @@ export default {
       context.store.commit('references/setSponsors', sponsorsRefRes.data.stories)
       context.store.commit('references/setNightlife', nightlifeRefRes.data.stories)
       context.store.commit('references/setSightseeing', sightseeingRefRes.data.stories)
-      
+
+      try {
+        const ticketData = await axios.get(`/tickets-data.json`)
+        context.store.commit('references/setTickets', ticketData)
+      } catch(e) {}
+
       if (context.payload && context.payload.tickets) {
         context.store.commit('references/setTickets', context.payload.tickets)      
-      } else {
-        try {
-          const ticketData = await fetch('/tickets-data.json').then(res => res.json())
-          context.store.commit('references/setTickets', ticketData)
-        } catch(e) {
-          // do nothing, fallback exists
-        }
       }
 
       context.store.commit('references/setLoaded', '1')

--- a/pages/_.vue
+++ b/pages/_.vue
@@ -84,6 +84,13 @@ export default {
       
       if (context.payload && context.payload.tickets) {
         context.store.commit('references/setTickets', context.payload.tickets)      
+      } else {
+        try {
+          const ticketData = await fetch('/tickets-data.json').then(res => res.json())
+          context.store.commit('references/setTickets', ticketData)
+        } catch(e) {
+          // do nothing, fallback exists
+        }
       }
 
       context.store.commit('references/setLoaded', '1')

--- a/pages/_.vue
+++ b/pages/_.vue
@@ -28,8 +28,6 @@ import Menu from '@/components/Menu.vue'
 import MobileMenu from '@/components/MobileMenu.vue'
 import Navigation from '@/components/Navigation.vue'
 
-import axios from 'axios'
-
 export default {
   computed: {
     isMainNavigationVisible() {
@@ -84,13 +82,9 @@ export default {
       context.store.commit('references/setNightlife', nightlifeRefRes.data.stories)
       context.store.commit('references/setSightseeing', sightseeingRefRes.data.stories)
 
-      try {
-        const ticketData = await axios.get(`/tickets-data.json`)
-        context.store.commit('references/setTickets', ticketData)
-      } catch(e) {}
-
       if (context.payload && context.payload.tickets) {
-        context.store.commit('references/setTickets', context.payload.tickets)      
+        context.store.commit('references/setTickets', context.payload.tickets)
+        context.store.commit('references/setTicketsLoaded', '1')
       }
 
       context.store.commit('references/setLoaded', '1')

--- a/post-generate.js
+++ b/post-generate.js
@@ -1,5 +1,5 @@
 const { download, parseTickets } = require('./download')
-const { promises: fs } = require('fs')
+const fs = require('fs')
 
 download().then(data => {
   const titoTickets = parseTickets(data)

--- a/post-generate.js
+++ b/post-generate.js
@@ -3,5 +3,7 @@ const fs = require('fs')
 
 download().then(data => {
   const titoTickets = parseTickets(data)
-  fs.writeFile('./dist/ticket-data.json', JSON.stringify(titoTickets))
+  fs.writeFile('./dist/ticket-data.json', JSON.stringify(titoTickets), function(e) {
+    console.log(e)
+  })
 });

--- a/post-generate.js
+++ b/post-generate.js
@@ -1,0 +1,7 @@
+const { download, parseTickets } = require('./download')
+const { promises: fs } = require('fs')
+
+download().then(data => {
+  const titoTickets = parseTickets(data)
+  fs.writeFile('./dist/ticket-data.json', JSON.stringify(titoTickets))
+});

--- a/store/references.js
+++ b/store/references.js
@@ -25,6 +25,7 @@ export const state = () => ({
     }
   ],
   loaded: '0',
+  ticketsLoaded: '0'
 })
 
 export const mutations = {
@@ -45,6 +46,9 @@ export const mutations = {
   },
   setTickets (state, entries) {
     state.tickets = entries
+  },
+  setTicketsLoaded (state, loaded) {
+    state.ticketsLoaded = loaded
   },
   setSettings (state, settings) {
     state.settings = settings


### PR DESCRIPTION
Fixes bug where the demo data from the references.js file is shown

Reproduce bug:
1. Go to https://tsconf.eu/venue
2. Click the Home button
3. See ticket data from the reference store

PR solves this problem
- A post generate script loads the ticket-data from Tito and stores it in dist
- The moment the ticket reference component is loaded, we fetch the most up to date ticket-data from the server
- Update the Vuex Store, getting the real, up to date info

This call is not done when the component is not initialized dynamically :+1: