### PR TITLE
adds payload to all routes to fill store independently.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -115,23 +115,27 @@ export default {
               }
             })
           
-          // other routes that are not in Storyblok with their slug.
+          let payload = {
+            tickets: titoTickets
+          }
+          
+          // add routes manually or use the Links API of Storyblok to load all of them.
           let routes = [
-            { route: '/', payload: { tickets: titoTickets } },
-            { route: '/code-of-conduct', payload: {} },
-            { route: '/faq', payload: {} },
-            { route: '/legal-notice', payload: {} },
-            { route: '/venue', payload: {} },
-            { route: '/workshops', payload: {} },
-            { route: '/workshops/advanced-black-magic-with-typescript', payload: {} },
-            { route: '/workshops/tdd-with-typescript', payload: {} },
-            { route: '/speakers', payload: {} },
-            { route: '/speakers/anders-hejlsberg', payload: {} },
-            { route: '/speakers/liliana-kastilio', payload: {} },
-            { route: '/speakers/bert-belder', payload: {} },
-            { route: '/speakers/peter-kroener', payload: {} },
-            { route: '/speakers/david-tanzer', payload: {} },
-          ] // adds / directly
+            { route: '/', payload },
+            { route: '/code-of-conduct', payload },
+            { route: '/faq', payload },
+            { route: '/legal-notice', payload },
+            { route: '/venue', payload },
+            { route: '/workshops', payload },
+            { route: '/workshops/advanced-black-magic-with-typescript', payload },
+            { route: '/workshops/tdd-with-typescript', payload },
+            { route: '/speakers', payload },
+            { route: '/speakers/anders-hejlsberg', payload },
+            { route: '/speakers/liliana-kastilio', payload },
+            { route: '/speakers/bert-belder', payload },
+            { route: '/speakers/peter-kroener', payload },
+            { route: '/speakers/david-tanzer', payload },
+          ]
           // speakers, schedule, social
           callback(null, routes)
         } catch(e) {


### PR DESCRIPTION
Fixes bug where the demo data from the references.js file is shown

Reproduce bug:

1. Go to https://tsconf.eu/venue
2. Click the Home button
3. See ticket data from the reference store

This reuses the same payload logic, but passes it to all page generations to fill the store independently with that data.